### PR TITLE
set run_build_tables_exe cwd to repo root

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -269,6 +269,7 @@ fn buildTables(
     build_tables_mod.addImport("build_config", build_config_mod);
     build_tables_mod.addImport("types.zig", types_mod);
     const run_build_tables_exe = b.addRunArtifact(build_tables_exe);
+    run_build_tables_exe.setCwd(b.path(""));
     const tables_path = run_build_tables_exe.addOutputFileArg("tables.zig");
 
     return .{


### PR DESCRIPTION
Hello again :) still just getting my code to compile..

This was causing a filenotfound error when building as a dep in my project.