### PR TITLE
Add ability to shift unions

### DIFF
--- a/src/build/tables.zig
+++ b/src/build/tables.zig
@@ -353,8 +353,8 @@ fn TableTracking(comptime Struct: type) type {
 
     for (@typeInfo(Struct).@"struct".fields) |f| {
         switch (@typeInfo(f.type)) {
-            .@"struct" => {
-                if (@hasDecl(f.type, "Tracking")) {
+            .@"struct", .@"union" => {
+                if (@hasDecl(f.type, "Tracking") and f.type.Tracking != void) {
                     const T = @field(f.type, "Tracking");
                     tracking_fields[i] = .{
                         .name = f.name,

--- a/src/build/test_build_config.zig
+++ b/src/build/test_build_config.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const config = @import("config.zig");
 const config_x = @import("config.x.zig");
+const types = @import("types.zig");
 const d = config.default;
 
 const Allocator = std.mem.Allocator;
@@ -210,6 +211,67 @@ const next_or_prev = config.Extension{
         .{
             .name = "next_or_prev",
             .type = NextOrPrev,
+            .cp_packing = .shift,
+            .shift_low = -1,
+            .shift_high = 1,
+        },
+    },
+};
+
+fn computeNextOrPrevDirect(
+    allocator: Allocator,
+    cp: u21,
+    data: anytype,
+    b: anytype,
+    tracking: anytype,
+) Allocator.Error!void {
+    _ = allocator;
+    _ = b;
+    config.singleInit(
+        "next_or_prev_direct",
+        cp,
+        data,
+        tracking,
+        data.next_or_prev.unshift(cp),
+    );
+}
+
+const next_or_prev_direct = config.Extension{
+    .inputs = &.{"next_or_prev"},
+    .compute = &computeNextOrPrevDirect,
+    .fields = &.{
+        .{
+            .name = "next_or_prev_direct",
+            .type = NextOrPrev,
+        },
+    },
+};
+
+fn computeBidiPairedBracketDirect(
+    allocator: Allocator,
+    cp: u21,
+    data: anytype,
+    b: anytype,
+    tracking: anytype,
+) Allocator.Error!void {
+    _ = allocator;
+    _ = b;
+    config.singleInit(
+        "bidi_paired_bracket_direct",
+        cp,
+        data,
+        tracking,
+        data.bidi_paired_bracket.unshift(cp),
+    );
+}
+
+const bidi_paired_bracket_direct = config.Extension{
+    .inputs = &.{"bidi_paired_bracket"},
+    .compute = &computeBidiPairedBracketDirect,
+    .fields = &.{
+        .{
+            .name = "bidi_paired_bracket_direct",
+            .type = types.BidiPairedBracket,
         },
     },
 };
@@ -257,6 +319,8 @@ pub const tables = [_]config.Table{
             emoji_odd_or_even,
             info,
             next_or_prev,
+            next_or_prev_direct,
+            bidi_paired_bracket_direct,
         },
         .fields = &.{
             foo.field("foo"),
@@ -265,6 +329,8 @@ pub const tables = [_]config.Table{
             info.field("has_simple_lowercase"),
             info.field("numeric_value_numeric_reversed"),
             next_or_prev.field("next_or_prev"),
+            next_or_prev_direct.field("next_or_prev_direct"),
+            bidi_paired_bracket_direct.field("bidi_paired_bracket_direct"),
             d.field("name").override(.{
                 .embedded_len = 15,
                 .max_offset = 986096,
@@ -282,6 +348,7 @@ pub const tables = [_]config.Table{
         },
     },
     .{
+        .name = "pack",
         .packing = .@"packed",
         .extensions = &.{
             emoji_odd_or_even,

--- a/src/config.zig
+++ b/src/config.zig
@@ -239,7 +239,13 @@ pub const default = Table{
         .{ .name = "grapheme_break", .type = types.GraphemeBreak },
 
         // BidiPairedBracket field
-        .{ .name = "bidi_paired_bracket", .type = types.BidiPairedBracket },
+        .{
+            .name = "bidi_paired_bracket",
+            .type = types.BidiPairedBracket,
+            .cp_packing = .shift,
+            .shift_low = -3,
+            .shift_high = 3,
+        },
 
         // Block field
         .{ .name = "block", .type = types.Block },
@@ -688,7 +694,7 @@ pub fn singleInit(
     d: anytype,
 ) void {
     const F = @FieldType(@typeInfo(@TypeOf(data)).pointer.child, field);
-    if (@typeInfo(F) == .@"struct" and @hasDecl(F, "unshift")) {
+    if (@typeInfo(F) == .@"struct" and @hasDecl(F, "unshift") and @TypeOf(F.unshift) != void) {
         if (@typeInfo(@TypeOf(d)) == .optional) {
             @field(data, field) = .initOptional(
                 cp,

--- a/src/get.zig
+++ b/src/get.zig
@@ -117,10 +117,10 @@ fn DataField(comptime field: []const u8) type {
 fn FieldValue(comptime field: []const u8) type {
     const D = DataField(field);
     if (@typeInfo(D) == .@"struct") {
-        if (@hasDecl(D, "unpack")) {
-            return @typeInfo(@TypeOf(D.unpack)).@"fn".return_type.?;
-        } else if (@hasDecl(D, "unshift")) {
+        if (@hasDecl(D, "unshift") and @TypeOf(D.unshift) != void) {
             return @typeInfo(@TypeOf(D.unshift)).@"fn".return_type.?;
+        } else if (@hasDecl(D, "unpack")) {
+            return @typeInfo(@TypeOf(D.unpack)).@"fn".return_type.?;
         } else if (@hasDecl(D, "value") and @typeInfo(@TypeOf(D.value)) != .void) {
             return @typeInfo(@TypeOf(D.value)).@"fn".return_type.?;
         } else {
@@ -143,10 +143,10 @@ pub fn get(comptime field: FieldEnum, cp: u21) TypeOf(field) {
 
     if (@typeInfo(D) == .@"struct" and (@hasDecl(D, "unpack") or @hasDecl(D, "unshift") or (@hasDecl(D, "value") and @typeInfo(@TypeOf(D.value)) != .void))) {
         const d = @field(data(table, cp), name);
-        if (@hasDecl(D, "unpack")) {
-            return d.unpack();
-        } else if (@hasDecl(D, "unshift")) {
+        if (@hasDecl(D, "unshift") and @TypeOf(D.unshift) != void) {
             return d.unshift(cp);
+        } else if (@hasDecl(D, "unpack")) {
+            return d.unpack();
         } else {
             return d.value();
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -76,16 +76,29 @@ test "get packed optional bool works" {
     try testing.expectEqual(null, get(.maybe_bit, 0x1236));
 }
 
-test "get union unpacked" {
+test "get union unpacked, shift" {
     try testing.expectEqual(@as(u21, 0x1234), get(.next_or_prev, 0x1233).next);
     try testing.expectEqual(@as(u21, 0x1200), get(.next_or_prev, 0x1201).prev);
     try testing.expectEqual(.none, get(.next_or_prev, 0x1235));
 }
 
-test "get union packed" {
+test "get union unpacked, direct" {
+    try testing.expectEqual(@as(u21, 0x1234), get(.next_or_prev_direct, 0x1233).next);
+    try testing.expectEqual(@as(u21, 0x1200), get(.next_or_prev_direct, 0x1201).prev);
+    try testing.expectEqual(.none, get(.next_or_prev_direct, 0x1235));
+}
+
+test "get union packed, shift" {
+    try testing.expectEqual(5, @bitSizeOf(@FieldType(TypeOfAll("pack"), "bidi_paired_bracket")));
     try testing.expectEqual(@as(u21, 0x0029), get(.bidi_paired_bracket, 0x0028).open);
     try testing.expectEqual(@as(u21, 0x2997), get(.bidi_paired_bracket, 0x2998).close);
     try testing.expectEqual(.none, get(.bidi_paired_bracket, 0x4000));
+}
+
+test "get union packed, direct" {
+    try testing.expectEqual(@as(u21, 0x0029), get(.bidi_paired_bracket_direct, 0x0028).open);
+    try testing.expectEqual(@as(u21, 0x2997), get(.bidi_paired_bracket_direct, 0x2998).close);
+    try testing.expectEqual(.none, get(.bidi_paired_bracket_direct, 0x4000));
 }
 
 test "special_casing_condition" {


### PR DESCRIPTION
This is a fair amount of code, but note how now the `BidiPairedBracket` union can pack down to 5 bits, if in a packed table!

cc @asibahi