### PR TITLE
wcwidth fixes: emoji modifiers and presentation selectors

### DIFF
--- a/src/x/config_x/wcwidth.zig
+++ b/src/x/config_x/wcwidth.zig
@@ -127,6 +127,8 @@ fn compute(
         // Note though that 0x1160 and up in hangul_jamo are
         // east_asian_width == .neutral
         data.wcwidth = 0;
+    } else if (data.is_emoji_modifier) {
+        data.wcwidth = 0;
     } else if (data.east_asian_width == .wide or data.east_asian_width == .fullwidth) {
         data.wcwidth = 2;
     } else if (data.grapheme_break == .regional_indicator) {
@@ -142,6 +144,7 @@ pub const wcwidth = config.Extension{
         "east_asian_width",
         "general_category",
         "grapheme_break",
+        "is_emoji_modifier",
     },
     .compute = &compute,
     .fields = &.{

--- a/src/x/grapheme.zig
+++ b/src/x/grapheme.zig
@@ -13,6 +13,12 @@ pub fn unverifiedWcwidth(const_it: anytype) i3 {
     while (it.nextCodepoint()) |result| {
         if (result.codepoint == uucode.config.zero_width_joiner) {
             width = 2;
+        } else if (result.codepoint == 0xFE0F) {
+            // Emoji presentation selector
+            width = 2;
+        } else if (result.codepoint == 0xFE0E) {
+            // Text presentation selector
+            width = 1;
         } else if (width <= 0) {
             width = uucode.get(.wcwidth, result.codepoint);
         }


### PR DESCRIPTION
This adds some `wcwidth` and `unverifiedWcwidth` fixes, currently just:

* Treat emoji modifiers as `wcwidth` of 0.
* Count any grapheme with the emoji presentation selector as width 2 (even those outside of the emoji-variation-sequences.txt for now)
* Count any grapheme with the text presentation selector as width 1

cc @rockorager