### PR TITLE
Add is_emoji_vs_base as the preferred way to check emoji variation se…

### DIFF
--- a/src/build/tables.zig
+++ b/src/build/tables.zig
@@ -910,11 +910,15 @@ pub fn writeTableData(
         if (comptime Ucd.needsSection(table_config, .emoji_vs)) {
             const emoji_vs = &ucd.emoji_vs[cp];
 
+            if (@hasField(AllData, "is_emoji_vs_base")) {
+                std.debug.assert(emoji_vs.is_text == emoji_vs.is_emoji);
+                a.is_emoji_vs_base = emoji_vs.is_text;
+            }
             if (@hasField(AllData, "is_emoji_vs_text")) {
-                a.is_emoji_vs_text = emoji_vs.text;
+                a.is_emoji_vs_text = emoji_vs.is_text;
             }
             if (@hasField(AllData, "is_emoji_vs_emoji")) {
-                a.is_emoji_vs_emoji = emoji_vs.emoji;
+                a.is_emoji_vs_emoji = emoji_vs.is_emoji;
             }
         }
 

--- a/src/build/test_build_config.zig
+++ b/src/build/test_build_config.zig
@@ -371,6 +371,7 @@ pub const tables = [_]config.Table{
             d.field("is_alphabetic"),
             d.field("is_lowercase"),
             d.field("is_uppercase"),
+            d.field("is_emoji_vs_base"),
         },
     },
     .{

--- a/src/config.zig
+++ b/src/config.zig
@@ -237,6 +237,16 @@ pub const default = Table{
         .{ .name = "is_extended_pictographic", .type = bool },
 
         // EmojiVariationSequences
+        // These are all going to be equivalent, but
+        // `emoji-variation-sequences.txt` and UTS #51 split out the emoji and
+        // text variation sequences separately. However, ever since these were
+        // introduced in Unicode 6.1 (see
+        // https://unicode.org/Public/6.1.0/ucd/StandardizedVariants.txt --
+        // dated 2011-11-10), until present, there has never been an emoji
+        // variation sequence that isn't also a valid text variation sequence,
+        // and vice versa, so the recommendation is to just use
+        // `is_emoji_vs_base`.
+        .{ .name = "is_emoji_vs_base", .type = bool },
         .{ .name = "is_emoji_vs_text", .type = bool },
         .{ .name = "is_emoji_vs_emoji", .type = bool },
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -130,3 +130,9 @@ test "info extension" {
     // MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH
     try testing.expect(std.mem.eql(u8, "061/1", get(.numeric_value_numeric_reversed, 0x0D58)));
 }
+
+test "is_emoji_vs_base" {
+    try testing.expect(get(.is_emoji_vs_base, 0x231B)); // ⌛
+    try testing.expect(get(.is_emoji_vs_base, 0x1F327)); // 🌧
+    try testing.expect(!get(.is_emoji_vs_base, 0x1F46C)); // 👬
+}


### PR DESCRIPTION
…quences.

See the comment in `src/config.zig`:

>        // These are all going to be equivalent, but
>        // `emoji-variation-sequences.txt` and UTS #51 split out the emoji and
>        // text variation sequences separately. However, ever since these were
>        // introduced in Unicode 6.1 (see
>        // https://unicode.org/Public/6.1.0/ucd/StandardizedVariants.txt --
>        // dated 2011-11-10), until present, there has never been an emoji
>        // variation sequence that isn't also a valid text variation sequence,
>        // and vice versa, so the recommendation is to just use
>        // `is_emoji_vs_base`.

cc @mitchellh 