### PR TITLE
`@Type` builtin is removed

### DIFF
--- a/src/get.zig
+++ b/src/get.zig
@@ -97,27 +97,20 @@ pub const FieldEnum = blk: {
         fields_len += @typeInfo(TableData(tableInfo.type)).@"struct".fields.len;
     }
 
-    var fields: [fields_len]std.builtin.Type.EnumField = undefined;
+    const TagInt = std.math.IntFittingRange(0, fields_len - 1);
+    var field_names: [fields_len][]const u8 = undefined;
+    var field_values: [fields_len]TagInt = undefined;
     var i: usize = 0;
 
     for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
         for (@typeInfo(TableData(tableInfo.type)).@"struct".fields) |f| {
-            fields[i] = .{
-                .name = f.name,
-                .value = i,
-            };
+            field_names[i] = f.name;
+            field_values[i] = i;
             i += 1;
         }
     }
 
-    break :blk @Type(.{
-        .@"enum" = .{
-            .tag_type = std.math.IntFittingRange(0, fields_len - 1),
-            .fields = &fields,
-            .decls = &[_]std.builtin.Type.Declaration{},
-            .is_exhaustive = true,
-        },
-    });
+    break :blk @Enum(TagInt, .exhaustive, &field_names, &field_values);
 };
 
 fn DataField(comptime field: []const u8) type {

--- a/src/types.zig
+++ b/src/types.zig
@@ -525,28 +525,29 @@ pub fn Field(comptime c: config.Field, comptime packing: config.Table.Packing) t
 }
 
 pub fn Data(comptime c: config.Table) type {
-    var data_fields: [c.fields.len]std.builtin.Type.StructField = undefined;
+    var data_field_names: [c.fields.len][]const u8 = undefined;
+    var data_field_types: [c.fields.len]type = undefined;
+    var data_field_attrs: [c.fields.len]std.builtin.Type.StructField.Attributes = undefined;
 
     for (c.fields, 0..) |cf, i| {
         const F = Field(cf, c.packing);
 
-        data_fields[i] = .{
-            .name = cf.name,
-            .type = F,
+        data_field_names[i] = cf.name;
+        data_field_types[i] = F;
+        data_field_attrs[i] = .{
+            .@"comptime" = false,
+            .@"align" = if (c.packing == .@"packed") null else @alignOf(F),
             .default_value_ptr = null,
-            .is_comptime = false,
-            .alignment = if (c.packing == .@"packed") 0 else @alignOf(F),
         };
     }
 
-    return @Type(.{
-        .@"struct" = .{
-            .layout = if (c.packing == .@"packed") .@"packed" else .auto,
-            .fields = &data_fields,
-            .decls = &[_]std.builtin.Type.Declaration{},
-            .is_tuple = false,
-        },
-    });
+    return @Struct(
+        if (c.packing == .@"packed") .@"packed" else .auto,
+        null,
+        &data_field_names,
+        &data_field_types,
+        &data_field_attrs,
+    );
 }
 
 pub fn writeDataItems(comptime D: type, writer: *std.Io.Writer, data_items: []const D) !void {
@@ -657,31 +658,32 @@ pub fn Table2(
 
 pub fn StructFromDecls(comptime Struct: type, comptime decl: []const u8) type {
     const fields = @typeInfo(Struct).@"struct".fields;
-    var decl_fields: [fields.len]std.builtin.Type.StructField = undefined;
+    var decl_field_names: [fields.len][]const u8 = undefined;
+    var decl_field_types: [fields.len]type = undefined;
+    var decl_field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
     var i: usize = 0;
 
     for (@typeInfo(Struct).@"struct".fields) |f| {
         if (@typeInfo(f.type) == .@"struct" and @hasDecl(f.type, decl)) {
             const T = @field(f.type, decl);
-            decl_fields[i] = .{
-                .name = f.name,
-                .type = T,
+            decl_field_names[i] = f.name;
+            decl_field_types[i] = T;
+            decl_field_attrs[i] = .{
+                .@"comptime" = false,
+                .@"align" = @alignOf(T),
                 .default_value_ptr = null, // TODO: can we set this?
-                .is_comptime = false,
-                .alignment = @alignOf(T),
             };
             i += 1;
         }
     }
 
-    return @Type(.{
-        .@"struct" = .{
-            .layout = .auto,
-            .fields = decl_fields[0..i],
-            .decls = &[_]std.builtin.Type.Declaration{},
-            .is_tuple = false,
-        },
-    });
+    return @Struct(
+        .auto,
+        null,
+        decl_field_names[0..i],
+        decl_field_types[0..i],
+        decl_field_attrs[0..i],
+    );
 }
 
 pub fn Slice(
@@ -1296,17 +1298,20 @@ pub fn Union(comptime c: config.Field, comptime packing: config.Table.Packing) t
 
     const ShiftMember = if (c.cp_packing == .shift) Shift(c, packing) else void;
 
-    var fields: [info.fields.len]std.builtin.Type.UnionField = undefined;
+    var field_names: [info.fields.len][]const u8 = undefined;
+    var field_types: [info.fields.len]type = undefined;
+    var field_attrs: [info.fields.len]std.builtin.Type.UnionField.Attributes = undefined;
     var has_shift: bool = false;
     for (info.fields, 0..) |f, i| {
         const T = if (c.cp_packing == .shift and f.type == u21) blk: {
             has_shift = true;
             break :blk ShiftMember;
         } else f.type;
-        fields[i] = .{
-            .name = f.name,
-            .type = T,
-            .alignment = if (packing == .@"packed") 0 else @alignOf(T),
+
+        field_names[i] = f.name;
+        field_types[i] = T;
+        field_attrs[i] = .{
+            .@"align" = if (packing == .@"packed") null else @alignOf(T),
         };
     }
 
@@ -1314,14 +1319,13 @@ pub fn Union(comptime c: config.Field, comptime packing: config.Table.Packing) t
         @compileError("Shift can only be used in unions with at least one field of type u21");
     }
 
-    const InnerUnion = @Type(.{
-        .@"union" = .{
-            .layout = if (packing == .@"packed") .@"packed" else .auto,
-            .tag_type = if (packing == .@"packed") null else Tag,
-            .fields = &fields,
-            .decls = &[_]std.builtin.Type.Declaration{},
-        },
-    });
+    const InnerUnion = @Union(
+        if (packing == .@"packed") .@"packed" else .auto,
+        if (packing == .@"packed") null else Tag,
+        &field_names,
+        &field_types,
+        &field_attrs,
+    );
 
     return if (packing == .unpacked) struct {
         @"union": InnerUnion,


### PR DESCRIPTION
After zig verison 0.16.0-dev.1888+9d497d0d7, `@Type` builtin is [removed](https://github.com/ziglang/zig/issues/10710).
This code remove all usage of `@Type` and replace appropriate alternative builtins. Plus, as zig introduce `std.Io`, this codebase also use `Io` interface.

Notice that this code breaks especially on zig 0.15.2.