### PR TITLE
add Bidi_Mirroring_Glyph property

### DIFF
--- a/src/components.zig
+++ b/src/components.zig
@@ -92,7 +92,7 @@ pub const build_components: []const config.Component = &.{
     },
     .{ .Impl = EmojiVs, .fields = &.{"is_emoji_vs_base"} },
     .{ .Impl = BidiPairedBracket, .fields = &.{"bidi_paired_bracket"} },
-    .{ .Impl = BidiMirroring, .fields = &.{"bidi_mirroring"} },
+    .{ .Impl = BidiMirroring, .fields = &.{ "bidi_mirroring", "bidi_mirroring_glyph" } },
     .{ .Impl = Blocks, .fields = &.{"block"} },
     .{ .Impl = Scripts, .fields = &.{"script"} },
     .{ .Impl = JoiningType, .fields = &.{"joining_type"} },
@@ -1293,6 +1293,8 @@ const BidiPairedBracket = struct {
 };
 
 const BidiMirroring = struct {
+    const fields = .{ "bidi_mirroring", "bidi_mirroring_glyph" };
+
     pub fn build(
         comptime InputRow: type,
         comptime Row: type,
@@ -1306,8 +1308,12 @@ const BidiMirroring = struct {
         _ = backing;
 
         rows.len = config.num_code_points;
-        const items = rows.items(.bidi_mirroring);
-        @memset(items, initField(Row, "bidi_mirroring", 0, null, tracking));
+        inline for (fields) |field| {
+            if (@hasField(Row, field)) {
+                const items = rows.items(@field(config.MultiSlice(Row).Field, field));
+                @memset(items, initField(Row, field, 0, null, tracking));
+            }
+        }
 
         const file_path = "ucd/BidiMirroring.txt";
 
@@ -1328,7 +1334,12 @@ const BidiMirroring = struct {
             const cp = try parseCp(cp_str);
             const paired = try parseCp(paired_cp_str);
 
-            items[cp] = initField(Row, "bidi_mirroring", cp, paired, tracking);
+            inline for (fields) |field| {
+                if (@hasField(Row, field)) {
+                    const items = rows.items(@field(config.MultiSlice(Row).Field, field));
+                    items[cp] = initField(Row, field, cp, paired, tracking);
+                }
+            }
         }
     }
 };

--- a/src/fields.zig
+++ b/src/fields.zig
@@ -300,6 +300,13 @@ pub const fields: []const config.Field = &.{
         .shift_low = -2527,
         .shift_high = 2527,
     },
+    .{
+        .name = "bidi_mirroring_glyph",
+        .type = ?u21,
+        .cp_packing = .shift,
+        .shift_low = -2527,
+        .shift_high = 2527,
+    },
 
     // Block
     .{ .name = "block", .type = types.Block },

--- a/src/root.zig
+++ b/src/root.zig
@@ -145,6 +145,30 @@ test "bidi_mirroring" {
     try testing.expectEqual(null, get(.bidi_mirroring, 0x0041)); // 'A'
 }
 
+test "bidi_mirroring_glyph" {
+    const cases = [_]struct { from: u21, to: u21 }{
+        .{ .from = 0x0028, .to = 0x0029 }, // LEFT PARENTHESIS
+        .{ .from = 0x0029, .to = 0x0028 }, // RIGHT PARENTHESIS
+        .{ .from = 0x005B, .to = 0x005D }, // LEFT SQUARE BRACKET
+        .{ .from = 0x005D, .to = 0x005B }, // RIGHT SQUARE BRACKET
+        .{ .from = 0x007B, .to = 0x007D }, // LEFT CURLY BRACKET
+        .{ .from = 0x007D, .to = 0x007B }, // RIGHT CURLY BRACKET
+        .{ .from = 0x003C, .to = 0x003E }, // LESS-THAN SIGN
+        .{ .from = 0x003E, .to = 0x003C }, // GREATER-THAN SIGN
+        .{ .from = 0x2215, .to = 0x29F5 }, // DIVISION SLASH
+        .{ .from = 0x29F5, .to = 0x2215 }, // REVERSE SOLIDUS OPERATOR
+        .{ .from = 0x2208, .to = 0x220B }, // ELEMENT OF
+        .{ .from = 0x220B, .to = 0x2208 }, // CONTAINS AS MEMBER
+    };
+
+    for (cases) |case| {
+        try testing.expectEqual(case.to, get(.bidi_mirroring_glyph, case.from));
+    }
+
+    try testing.expectEqual(null, get(.bidi_mirroring_glyph, 0xFD3E));
+    try testing.expectEqual(null, get(.bidi_mirroring_glyph, 0x0041)); // 'A'
+}
+
 test "block" {
     try testing.expectEqual(.basic_latin, get(.block, 0x0041)); // 'A'
     try testing.expectEqual(.greek_and_coptic, get(.block, 0x03B1)); // α

--- a/src/test/build_config.zig
+++ b/src/test/build_config.zig
@@ -215,6 +215,7 @@ pub const tables: []const config.Table = &.{
             "indic_positional_category",
             "indic_syllabic_category",
             "bidi_mirroring",
+            "bidi_mirroring_glyph",
         },
     },
     .{


### PR DESCRIPTION
## Summary
- exposes `Bidi_Mirroring_Glyph` as `uucode.get(.bidi_mirroring_glyph, cp) ?u21`
- derives the new field from the existing deterministic `ucd/BidiMirroring.txt` parser while preserving the existing `bidi_mirroring` field
- adds regression coverage for mirrored punctuation/brackets/math symbols plus default-null cases

## Verification
- `zig build`
- `zig build test`

## Note
This targets `zig-0.15` because Ghostty v1.3.1 is pinned to Zig 0.15.2. Upstream `main` currently requires Zig 0.16.0, so this branch is the compatible path for existing Ghostty consumers.