### PR TITLE
Migrate to zig 0.17.0 (master)

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -84,8 +84,8 @@ pub const Field = struct {
                 .max_value = self.max_value,
             };
 
-            inline for (@typeInfo(@TypeOf(overrides)).@"struct".fields) |f| {
-                @field(result, f.name) = @field(overrides, f.name);
+            inline for (@typeInfo(@TypeOf(overrides)).@"struct".field_names) |field_name| {
+                @field(result, field_name) = @field(overrides, field_name);
             }
 
             return result;
@@ -219,8 +219,8 @@ pub const Field = struct {
             .@"union" => {
                 if (self.cp_packing == .shift) {
                     const info = @typeInfo(self.type).@"union";
-                    const has_u21 = for (info.fields) |f| {
-                        if (f.type == u21) break true;
+                    const has_u21 = for (info.field_types) |field_type| {
+                        if (field_type == u21) break true;
                     } else false;
                     if (!has_u21) {
                         @compileError("Union field '" ++ self.name ++ "' with shift packing must have at least one u21 member");
@@ -270,8 +270,8 @@ pub const Field = struct {
                 return isPackable(optional.child);
             },
             .@"union" => |info| {
-                return for (info.fields) |f| {
-                    if (f.type != void and !isPackable(f.type)) {
+                return for (info.field_types) |field_type| {
+                    if (field_type != void and !isPackable(field_type)) {
                         break false;
                     }
                 } else true;
@@ -303,19 +303,19 @@ pub const Field = struct {
     pub fn override(self: Field, overrides: anytype) Field {
         var result = self;
 
-        inline for (@typeInfo(@TypeOf(overrides)).@"struct".fields) |f| {
-            if (!is_updating_ucd and (std.mem.eql(u8, f.name, "name") or
-                std.mem.eql(u8, f.name, "type") or
-                std.mem.eql(u8, f.name, "shift_low") or
-                std.mem.eql(u8, f.name, "shift_high") or
-                std.mem.eql(u8, f.name, "max_len") or
-                std.mem.eql(u8, f.name, "min_value") or
-                std.mem.eql(u8, f.name, "max_value")))
+        inline for (@typeInfo(@TypeOf(overrides)).@"struct".field_names) |field_name| {
+            if (!is_updating_ucd and (std.mem.eql(u8, field_name, "name") or
+                std.mem.eql(u8, field_name, "type") or
+                std.mem.eql(u8, field_name, "shift_low") or
+                std.mem.eql(u8, field_name, "shift_high") or
+                std.mem.eql(u8, field_name, "max_len") or
+                std.mem.eql(u8, field_name, "min_value") or
+                std.mem.eql(u8, field_name, "max_value")))
             {
-                @compileError("Cannot override field '" ++ f.name ++ "'");
+                @compileError("Cannot override field '" ++ field_name ++ "'");
             }
 
-            @field(result, f.name) = @field(overrides, f.name);
+            @field(result, field_name) = @field(overrides, field_name);
         }
 
         return result;
@@ -806,7 +806,7 @@ pub inline fn initField(
     if (@hasField(Track, name)) {
         const FT = @FieldType(Track, name);
         if (@hasDecl(FT, "track")) {
-            const params = @typeInfo(@TypeOf(FT.track)).@"fn".params;
+            const params = @typeInfo(@TypeOf(FT.track)).@"fn".param_types;
             if (params.len == 3) {
                 @field(tracking, name).track(cp, value);
             } else if (params.len == 2) {
@@ -820,7 +820,7 @@ pub inline fn initField(
     switch (@typeInfo(F)) {
         .@"struct", .@"union", .@"enum", .@"opaque" => {
             if (@hasDecl(F, "init")) {
-                const params = @typeInfo(@TypeOf(F.init)).@"fn".params;
+                const params = @typeInfo(@TypeOf(F.init)).@"fn".param_types;
                 if (params.len == 1) {
                     return F.init(value);
                 } else if (params.len == 2) {
@@ -870,7 +870,7 @@ pub inline fn initAllocField(
     switch (@typeInfo(F)) {
         .@"struct", .@"union", .@"enum", .@"opaque" => {
             if (@hasDecl(F, "init")) {
-                const params = @typeInfo(@TypeOf(F.init)).@"fn".params;
+                const params = @typeInfo(@TypeOf(F.init)).@"fn".param_types;
                 if (params.len == 3) {
                     return try .init(
                         allocator,

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -270,8 +270,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
         );
 
         var backing_subset: BackingInputSubset = undefined;
-        inline for (@typeInfo(BackingInputSubset).@"struct".fields) |field| {
-            @field(backing_subset, field.name) = @field(backing, field.name);
+        inline for (@typeInfo(BackingInputSubset).@"struct".field_names) |field_name| {
+            @field(backing_subset, field_name) = @field(backing, field_name);
         }
 
         const Tracking = config.Tracking(
@@ -282,13 +282,13 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
         var tracking: Tracking = undefined;
 
-        inline for (@typeInfo(Tracking).@"struct".fields) |field| {
-            const F = @FieldType(Tracking, field.name);
+        inline for (@typeInfo(Tracking).@"struct".field_names) |field_name| {
+            const F = @FieldType(Tracking, field_name);
             if (@hasDecl(F, "init")) {
-                const f = config.field(fields, field.name);
-                @field(tracking, field.name) = try .init(allocator, f);
+                const f = config.field(fields, field_name);
+                @field(tracking, field_name) = try .init(allocator, f);
             } else {
-                @field(tracking, field.name) = .{};
+                @field(tracking, field_name) = .{};
             }
         }
 
@@ -305,14 +305,14 @@ pub fn main(init: std.process.Init.Minimal) !void {
             &tracking,
         );
 
-        inline for (@typeInfo(Tracking).@"struct".fields) |field| {
-            const t = &@field(tracking, field.name);
-            const f = config.field(fields, field.name);
+        inline for (@typeInfo(Tracking).@"struct".field_names) |field_name| {
+            const t = &@field(tracking, field_name);
+            const f = config.field(fields, field_name);
             if (!try t.okay(f)) {
                 all_okay = false;
             }
-            if (@hasField(BackingOutputSubset, field.name)) {
-                @field(backing, field.name) = try t.toOwnedBacking(allocator);
+            if (@hasField(BackingOutputSubset, field_name)) {
+                @field(backing, field_name) = try t.toOwnedBacking(allocator);
             }
             t.deinit(allocator);
         }
@@ -374,18 +374,19 @@ pub fn main(init: std.process.Init.Minimal) !void {
         \\
     );
 
-    inline for (@typeInfo(Backing).@"struct".fields) |field| {
-        const info = @typeInfo(field.type);
+    const backing_info = @typeInfo(Backing).@"struct";
+    inline for (backing_info.field_names, backing_info.field_types) |field_name, field_type| {
+        const info = @typeInfo(field_type);
         if (info != .pointer or info.pointer.size != .slice) continue;
 
         const T = info.pointer.child;
 
         try writer.print("const backing_{s}: []const {s} = ", .{
-            field.name,
+            field_name,
             @typeName(T),
         });
 
-        const b = @field(backing, field.name);
+        const b = @field(backing, field_name);
 
         if (T == u8) {
             try writer.print("\"{s}\";\n", .{b});
@@ -425,16 +426,16 @@ pub fn main(init: std.process.Init.Minimal) !void {
         \\
     );
 
-    inline for (@typeInfo(Backing).@"struct".fields) |field| {
-        const info = @typeInfo(field.type);
+    inline for (backing_info.field_names, backing_info.field_types) |field_name, field_type| {
+        const info = @typeInfo(field_type);
         if (info == .pointer and info.pointer.size == .slice) {
             try writer.print("    .{s} = backing_{s},\n", .{
-                field.name,
-                field.name,
+                field_name,
+                field_name,
             });
         } else {
-            try writer.print("    .{s} = ", .{field.name});
-            try @field(backing, field.name).write(writer);
+            try writer.print("    .{s} = ", .{field_name});
+            try @field(backing, field_name).write(writer);
             try writer.writeAll(",\n");
         }
     }
@@ -525,23 +526,25 @@ pub fn main(init: std.process.Init.Minimal) !void {
 }
 
 fn hashRow(comptime Row: type, hasher: anytype, row: Row) void {
-    inline for (@typeInfo(Row).@"struct".fields) |field| {
-        if (comptime @typeInfo(field.type) == .@"struct" and @hasDecl(field.type, "autoHash")) {
-            @field(row, field.name).autoHash(hasher);
+    const row_info = @typeInfo(Row).@"struct";
+    inline for (row_info.field_names, row_info.field_types) |field_name, field_type| {
+        if (comptime @typeInfo(field_type) == .@"struct" and @hasDecl(field_type, "autoHash")) {
+            @field(row, field_name).autoHash(hasher);
         } else {
-            std.hash.autoHash(hasher, @field(row, field.name));
+            std.hash.autoHash(hasher, @field(row, field_name));
         }
     }
 }
 
 fn eqlRow(comptime Row: type, a: Row, b: Row) bool {
-    inline for (@typeInfo(Row).@"struct".fields) |field| {
-        if (comptime @typeInfo(field.type) == .@"struct" and @hasDecl(field.type, "eql")) {
-            if (!@field(a, field.name).eql(@field(b, field.name))) {
+    const row_info = @typeInfo(Row).@"struct";
+    inline for (row_info.field_names, row_info.field_types) |field_name, field_type| {
+        if (comptime @typeInfo(field_type) == .@"struct" and @hasDecl(field_type, "eql")) {
+            if (!@field(a, field_name).eql(@field(b, field_name))) {
                 return false;
             }
         } else {
-            if (!std.meta.eql(@field(a, field.name), @field(b, field.name))) {
+            if (!std.meta.eql(@field(a, field_name), @field(b, field_name))) {
                 return false;
             }
         }
@@ -797,7 +800,7 @@ pub fn writeTableRows(
     );
 
     if (@typeInfo(Row).@"struct".layout == .@"packed") {
-        const IntEquivalent = std.meta.Int(.unsigned, @bitSizeOf(Row));
+        const IntEquivalent = @Int(.unsigned, @bitSizeOf(Row));
 
         try writer.print("&@as([{d}]{s}_Row, @bitCast([_]{s}{{\n", .{ rows.len, TypePrefix, @typeName(IntEquivalent) });
 
@@ -815,16 +818,17 @@ pub fn writeTableRows(
             \\
         );
 
+        const row_info = @typeInfo(Row).@"struct";
         for (rows) |row| {
             try writer.writeAll(
                 \\.{
                 \\
             );
 
-            inline for (@typeInfo(Row).@"struct".fields) |field| {
-                try writer.print("    .{s} = ", .{field.name});
+            inline for (row_info.field_names, row_info.field_types) |field_name, field_type| {
+                try writer.print("    .{s} = ", .{field_name});
 
-                try storage.writeField(field.type, writer, @field(row, field.name));
+                try storage.writeField(field_type, writer, @field(row, field_name));
 
                 try writer.writeAll(",\n");
             }

--- a/src/get.zig
+++ b/src/get.zig
@@ -11,10 +11,11 @@ fn TableData(comptime Table: anytype) type {
     return @typeInfo(DataSlice).pointer.child;
 }
 
-fn tableInfoFor(comptime field: []const u8) std.builtin.Type.StructField {
-    inline for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
-        if (@hasField(TableData(tableInfo.type), field)) {
-            return tableInfo;
+fn tableNameFor(comptime field: []const u8) [:0]const u8 {
+    const info = @typeInfo(@TypeOf(tables)).@"struct";
+    inline for (info.field_names, info.field_types) |field_name, field_type| {
+        if (@hasField(TableData(field_type), field)) {
+            return field_name;
         }
     }
 
@@ -22,8 +23,9 @@ fn tableInfoFor(comptime field: []const u8) std.builtin.Type.StructField {
 }
 
 pub fn hasField(comptime field: []const u8) bool {
-    inline for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
-        if (@hasField(TableData(tableInfo.type), field)) {
+    const info = @typeInfo(@TypeOf(tables)).@"struct";
+    inline for (info.field_types) |field_type| {
+        if (@hasField(TableData(field_type), field)) {
             return true;
         }
     }
@@ -40,18 +42,18 @@ pub fn backingFor(comptime field: []const u8) BackingFor(field) {
 }
 
 fn TableFor(comptime field: []const u8) type {
-    const tableInfo = tableInfoFor(field);
-    return @FieldType(@TypeOf(tables), tableInfo.name);
+    return @FieldType(@TypeOf(tables), tableNameFor(field));
 }
 
 fn tableFor(comptime field: []const u8) TableFor(field) {
-    return @field(tables, tableInfoFor(field).name);
+    return @field(tables, tableNameFor(field));
 }
 
 fn GetTable(comptime table_name: []const u8) type {
-    inline for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
-        if (std.mem.eql(u8, tableInfo.name, table_name)) {
-            return tableInfo.type;
+    const info = @typeInfo(@TypeOf(tables)).@"struct";
+    inline for (info.field_names, info.field_types) |field_name, field_type| {
+        if (std.mem.eql(u8, field_name, table_name)) {
+            return field_type;
         }
     }
 
@@ -82,9 +84,10 @@ pub fn TypeOfAll(comptime table_name: []const u8) type {
 }
 
 pub const FieldEnum = blk: {
+    const tables_info = @typeInfo(@TypeOf(tables)).@"struct";
     var fields_len: usize = 0;
-    for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
-        fields_len += @typeInfo(TableData(tableInfo.type)).@"struct".fields.len;
+    for (tables_info.field_types) |field_type| {
+        fields_len += @typeInfo(TableData(field_type)).@"struct".field_names.len;
     }
 
     const TagInt = std.math.IntFittingRange(0, fields_len - 1);
@@ -92,9 +95,9 @@ pub const FieldEnum = blk: {
     var field_values: [fields_len]TagInt = undefined;
     var i: usize = 0;
 
-    for (@typeInfo(@TypeOf(tables)).@"struct".fields) |tableInfo| {
-        for (@typeInfo(TableData(tableInfo.type)).@"struct".fields) |f| {
-            field_names[i] = f.name;
+    for (tables_info.field_types) |field_type| {
+        for (@typeInfo(TableData(field_type)).@"struct".field_names) |field_name| {
+            field_names[i] = field_name;
             field_values[i] = i;
             i += 1;
         }
@@ -104,7 +107,7 @@ pub const FieldEnum = blk: {
 };
 
 fn DataField(comptime field: []const u8) type {
-    return @FieldType(TableData(tableInfoFor(field).type), field);
+    return @FieldType(TableData(TableFor(field)), field);
 }
 
 pub fn WithBacking(comptime S: type) type {

--- a/src/grapheme.zig
+++ b/src/grapheme.zig
@@ -535,23 +535,23 @@ pub fn GraphemeBreakTable(comptime GB: type, comptime State: type) type {
         result: bool,
         state: State,
     };
-    const gb_fields = @typeInfo(GB).@"enum".fields;
-    const state_fields = @typeInfo(State).@"enum".fields;
-    const n_gb = gb_fields.len;
+    const gb_values = @typeInfo(GB).@"enum".field_values;
+    const state_values = @typeInfo(State).@"enum".field_values;
+    const n_gb = gb_values.len;
     const n_gb_2 = n_gb * n_gb;
-    const n_state = state_fields.len;
+    const n_state = state_values.len;
     const n = n_state * n_gb_2;
 
     // Assert that these are simple enums (this isn't a full assertion, but
     // likely good enough.)
-    inlineAssert(gb_fields[gb_fields.len - 1].value == n_gb - 1);
-    inlineAssert(state_fields[state_fields.len - 1].value == n_state - 1);
+    inlineAssert(gb_values[gb_values.len - 1] == n_gb - 1);
+    inlineAssert(state_values[state_values.len - 1] == n_state - 1);
 
     return struct {
         data: [n]Result,
 
         inline fn index(gb1: GB, gb2: GB, state: State) usize {
-            return @intFromEnum(state) * n_gb_2 + @intFromEnum(gb1) * n_gb + @intFromEnum(gb2);
+            return @backingInt(state) * n_gb_2 + @backingInt(gb1) * n_gb + @backingInt(gb2);
         }
 
         pub fn set(self: *@This(), gb1: GB, gb2: GB, state: State, result: Result) void {
@@ -572,15 +572,15 @@ pub fn buildGraphemeBreakTable(
     @setEvalBranchQuota(20_000);
     var table: GraphemeBreakTable(GB, State) = undefined;
 
-    const gb_fields = @typeInfo(GB).@"enum".fields;
-    const state_fields = @typeInfo(State).@"enum".fields;
+    const gb_values = @typeInfo(GB).@"enum".field_values;
+    const state_values = @typeInfo(State).@"enum".field_values;
 
-    for (state_fields) |state_field| {
-        for (gb_fields) |gb1_field| {
-            for (gb_fields) |gb2_field| {
-                const original_state: State = @enumFromInt(state_field.value);
-                const gb1: GB = @enumFromInt(gb1_field.value);
-                const gb2: GB = @enumFromInt(gb2_field.value);
+    for (state_values) |state_value| {
+        for (gb_values) |gb1_value| {
+            for (gb_values) |gb2_value| {
+                const original_state: State = @fromBackingInt(@intCast(state_value));
+                const gb1: GB = @fromBackingInt(@intCast(gb1_value));
+                const gb2: GB = @fromBackingInt(@intCast(gb2_value));
                 var state = original_state;
                 const result = compute(gb1, gb2, &state);
                 table.set(gb1, gb2, original_state, .{

--- a/src/multi_slice.zig
+++ b/src/multi_slice.zig
@@ -6,10 +6,13 @@ const inlineAssert = @import("config.zig").quirks.inlineAssert;
 /// issues with large structs.
 pub fn MultiSlice(comptime T: type) type {
     @setEvalBranchQuota(50_000);
-    const fields = std.meta.fields(T);
+    const info = @typeInfo(T).@"struct";
+    const field_names = info.field_names;
+    const field_types = info.field_types;
+    const field_attrs = info.field_attrs;
 
     return struct {
-        ptrs: [fields.len][*]u8,
+        ptrs: [field_names.len][*]u8,
         len: usize,
         capacity: usize,
 
@@ -27,7 +30,7 @@ pub fn MultiSlice(comptime T: type) type {
             if (self.capacity == 0) {
                 return &[_]F{};
             }
-            const byte_ptr = self.ptrs[@intFromEnum(field)];
+            const byte_ptr = self.ptrs[@backingInt(field)];
             const casted_ptr: [*]F = if (@sizeOf(F) == 0)
                 undefined
             else
@@ -36,26 +39,26 @@ pub fn MultiSlice(comptime T: type) type {
         }
 
         pub fn set(self: Self, index: usize, elem: T) void {
-            inline for (fields, 0..) |field_info, i| {
-                self.items(@as(Field, @enumFromInt(i)))[index] = @field(elem, field_info.name);
+            inline for (field_names, 0..) |field_name, i| {
+                self.items(@as(Field, @fromBackingInt(@intCast(i))))[index] = @field(elem, field_name);
             }
         }
 
         pub fn get(self: Self, index: usize) T {
             var result: T = undefined;
-            inline for (fields, 0..) |field_info, i| {
-                @field(result, field_info.name) = self.items(@as(Field, @enumFromInt(i)))[index];
+            inline for (field_names, 0..) |field_name, i| {
+                @field(result, field_name) = self.items(@as(Field, @fromBackingInt(@intCast(i))))[index];
             }
             return result;
         }
 
         pub fn subset(self: Self, comptime Subset: type) MultiSlice(Subset) {
-            const subset_fields = std.meta.fields(Subset);
+            const subset_field_names = @typeInfo(Subset).@"struct".field_names;
             var result: MultiSlice(Subset) = undefined;
-            inline for (subset_fields, 0..) |sf, dst_idx| {
-                const src_idx = comptime for (fields, 0..) |f, i| {
-                    if (std.mem.eql(u8, f.name, sf.name)) break i;
-                } else @compileError("subset field '" ++ sf.name ++ "' not found in source");
+            inline for (subset_field_names, 0..) |subset_field_name, dst_idx| {
+                const src_idx = comptime for (field_names, 0..) |field_name, i| {
+                    if (std.mem.eql(u8, field_name, subset_field_name)) break i;
+                } else @compileError("subset field '" ++ subset_field_name ++ "' not found in source");
                 result.ptrs[dst_idx] = self.ptrs[src_idx];
             }
             result.len = self.len;
@@ -64,31 +67,13 @@ pub fn MultiSlice(comptime T: type) type {
         }
 
         pub fn memset(self: Self, elem: T) void {
-            inline for (fields, 0..) |field_info, i| {
-                const field: Field = @enumFromInt(i);
-                const value = @field(elem, field_info.name);
-                const F = field_info.type;
+            inline for (field_names, field_types, 0..) |field_name, field_type, i| {
+                const field: Field = @fromBackingInt(@intCast(i));
                 const slice = self.items(field);
-                if (@sizeOf(F) == 0) {
+                if (@sizeOf(field_type) == 0) {
                     // Zero-size types have nothing to set.
-                } else if (@bitSizeOf(F) != @sizeOf(F) * 8) {
-                    // Types like bool, u3, or enum(u2) have fewer bits than
-                    // their storage size, so @memset can't be called directly
-                    // on their slices. Convert to a byte-array representation
-                    // by zero-extending into a storage-sized int, then @memset
-                    // the reinterpreted byte array for the same performance as
-                    // a normal @memset.
-                    const StorageInt = std.meta.Int(.unsigned, @sizeOf(F) * 8);
-                    const storage: StorageInt = switch (@typeInfo(F)) {
-                        .int => @intCast(value),
-                        .bool => @intFromBool(value),
-                        .@"enum" => @intFromEnum(value),
-                        else => @compileError("memset: unsupported non-byte-aligned type '" ++ @typeName(F) ++ "'"),
-                    };
-                    const ints: [*]StorageInt = @ptrCast(slice.ptr);
-                    @memset(ints[0..slice.len], storage);
                 } else {
-                    @memset(slice, value);
+                    @memset(slice, @field(elem, field_name));
                 }
             }
         }
@@ -100,7 +85,7 @@ pub fn MultiSlice(comptime T: type) type {
         }
 
         pub fn initCapacity(allocator: std.mem.Allocator, capacity: usize) std.mem.Allocator.Error!Self {
-            if (fields.len == 0 or capacity == 0) {
+            if (field_names.len == 0 or capacity == 0) {
                 return .{ .ptrs = undefined, .len = 0, .capacity = capacity };
             }
             const byte_count = capacityInBytes(capacity);
@@ -116,41 +101,44 @@ pub fn MultiSlice(comptime T: type) type {
 
         const alignment: std.mem.Alignment = blk: {
             var max_align: usize = 1;
-            for (fields) |field_info| {
-                const a: usize = if (@sizeOf(field_info.type) == 0)
+            for (field_types, field_attrs) |field_type, attrs| {
+                // A zero-size field contributes no bytes to the
+                // allocation, so it can't misalign anything; treat it as
+                // alignment 1 regardless of any explicit override.
+                const a: usize = if (@sizeOf(field_type) == 0)
                     1
                 else
-                    field_info.alignment orelse @alignOf(field_info.type);
+                    attrs.@"align" orelse @alignOf(field_type);
                 if (a > max_align) max_align = a;
             }
-            break :blk @enumFromInt(std.math.log2(max_align));
+            break :blk @fromBackingInt(@intCast(std.math.log2(max_align)));
         };
 
-        const sorted_sizes: [fields.len]usize = blk: {
-            var sizes: [fields.len]usize = undefined;
+        const sorted_sizes: [field_names.len]usize = blk: {
+            var sizes: [field_names.len]usize = undefined;
             for (sortOrder(), 0..) |si, i| {
-                sizes[i] = @sizeOf(fields[si].type);
+                sizes[i] = @sizeOf(field_types[si]);
             }
             break :blk sizes;
         };
 
-        const sorted_fields: [fields.len]usize = sortOrder();
+        const sorted_fields: [field_names.len]usize = sortOrder();
 
-        fn sortOrder() [fields.len]usize {
-            @setEvalBranchQuota(fields.len * fields.len + 100);
-            var order: [fields.len]usize = undefined;
-            for (0..fields.len) |i| order[i] = i;
-            for (0..fields.len) |i| {
+        fn sortOrder() [field_names.len]usize {
+            @setEvalBranchQuota(field_names.len * field_names.len + 100);
+            var order: [field_names.len]usize = undefined;
+            for (0..field_names.len) |i| order[i] = i;
+            for (0..field_names.len) |i| {
                 var best = i;
-                for (i + 1..fields.len) |j| {
-                    const best_align = if (@sizeOf(fields[order[best]].type) == 0)
+                for (i + 1..field_names.len) |j| {
+                    const best_align = if (@sizeOf(field_types[order[best]]) == 0)
                         1
                     else
-                        fields[order[best]].alignment orelse @alignOf(fields[order[best]].type);
-                    const j_align = if (@sizeOf(fields[order[j]].type) == 0)
+                        field_attrs[order[best]].@"align" orelse @alignOf(field_types[order[best]]);
+                    const j_align = if (@sizeOf(field_types[order[j]]) == 0)
                         1
                     else
-                        fields[order[j]].alignment orelse @alignOf(fields[order[j]].type);
+                        field_attrs[order[j]].@"align" orelse @alignOf(field_types[order[j]]);
                     if (j_align > best_align) best = j;
                 }
                 const tmp = order[i];

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -6,7 +6,7 @@ const Allocator = std.mem.Allocator;
 
 pub fn RoundedInt(comptime signedness: std.builtin.Signedness, comptime bit_count: u16) type {
     const rounded_bits = std.mem.alignForward(u16, if (bit_count == 0) 1 else bit_count, 8);
-    return std.meta.Int(signedness, rounded_bits);
+    return @Int(signedness, rounded_bits);
 }
 
 pub fn RoundedIntFitting(comptime from: comptime_int, comptime to: comptime_int) type {
@@ -75,7 +75,7 @@ pub fn Row(
     @setEvalBranchQuota(50_000);
     var field_names: [fields.len][]const u8 = undefined;
     var field_types: [fields.len]type = undefined;
-    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.Struct.FieldAttributes = undefined;
 
     for (fields, fields_is_packed, 0..) |field, is_field_packed, i| {
         const F = Field(field, is_field_packed or table_packing == .@"packed");
@@ -104,7 +104,7 @@ pub fn DeclStruct(
     @setEvalBranchQuota(fields.len * 100 + 1000);
     var field_names: [fields.len][]const u8 = undefined;
     var field_types: [fields.len]type = undefined;
-    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.Struct.FieldAttributes = undefined;
     var i: usize = 0;
 
     for (fields, fields_is_packed) |field, is_field_packed| {
@@ -225,7 +225,7 @@ pub fn Slice(
                 .len = 0,
                 .data = .{
                     .embedded = @splat(switch (@typeInfo(T)) {
-                        .@"enum" => @enumFromInt(0),
+                        .@"enum" => @fromBackingInt(@intCast(0)),
                         else => 0,
                     }),
                 },
@@ -233,7 +233,7 @@ pub fn Slice(
         pub const same = if (is_shift) Self{
             .data = .{ .shift = .same },
             .len = 1,
-        } else void{};
+        } else {};
 
         inline fn initInner(
             allocator: Allocator,
@@ -279,7 +279,7 @@ pub fn Slice(
                         @memset(embedded[s.len..], 0);
                     },
                     .@"enum" => {
-                        @memset(embedded[s.len..], @enumFromInt(0));
+                        @memset(embedded[s.len..], @fromBackingInt(@intCast(0)));
                     },
                     else => {
                         @memset(embedded[s.len..], 0);
@@ -351,10 +351,7 @@ pub fn Slice(
             }
         }
 
-        pub const value = if (is_shift)
-            void{}
-        else
-            _value;
+        pub const value = if (is_shift) {} else _value;
 
         fn _valueWith(
             self: *const Self,
@@ -372,8 +369,7 @@ pub fn Slice(
 
         pub const valueWith = if (T == u21)
             _valueWith
-        else
-            void{};
+        else {};
 
         pub fn autoHash(self: Self, hasher: anytype) void {
             std.hash.autoHash(hasher, self.len);
@@ -671,7 +667,7 @@ pub fn PackedOptional(comptime T: type, comptime DataInt: type) type {
             if (opt) |value| {
                 const d: DataInt = switch (@typeInfo(T)) {
                     .int => value,
-                    .@"enum" => @intFromEnum(value),
+                    .@"enum" => @backingInt(value),
                     .bool => @intFromBool(value),
                     else => unreachable,
                 };
@@ -688,7 +684,7 @@ pub fn PackedOptional(comptime T: type, comptime DataInt: type) type {
             } else {
                 return switch (@typeInfo(T)) {
                     .int => @intCast(self.data),
-                    .@"enum" => @enumFromInt(self.data),
+                    .@"enum" => @fromBackingInt(@intCast(self.data)),
                     .bool => self.data == 1,
                     else => unreachable,
                 };
@@ -714,7 +710,7 @@ pub fn OptionalTracking(comptime Optional: type) type {
             if (opt) |value| {
                 const d: isize = switch (@typeInfo(T)) {
                     .int => value,
-                    .@"enum" => @intFromEnum(value),
+                    .@"enum" => @backingInt(value),
                     .bool => @intFromBool(value),
                     else => unreachable,
                 };
@@ -865,24 +861,24 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
     const info = @typeInfo(T).@"union";
     const Tag = info.tag_type.?;
     const Int = @typeInfo(Tag).@"enum".tag_type;
-    inlineAssert(Int == std.meta.Int(.unsigned, @bitSizeOf(Tag)));
+    inlineAssert(Int == @Int(.unsigned, @bitSizeOf(Tag)));
 
     const ShiftMember = if (is_shift)
         Shift(_ShiftInt, false, is_packed)
     else
         void;
 
-    var field_names: [info.fields.len][]const u8 = undefined;
-    var field_types: [info.fields.len]type = undefined;
-    var field_attrs: [info.fields.len]std.builtin.Type.UnionField.Attributes = undefined;
-    for (info.fields, 0..) |f, i| {
-        const FieldType = if (is_shift and f.type == u21)
+    var field_names: [info.field_names.len][]const u8 = undefined;
+    var field_types: [info.field_names.len]type = undefined;
+    var field_attrs: [info.field_names.len]std.builtin.Type.Union.FieldAttributes = undefined;
+    for (info.field_names, info.field_types, 0..) |field_name, field_type, i| {
+        const FieldType = if (is_shift and field_type == u21)
             ShiftMember
-        else if (is_packed and is_shift and f.type == void)
+        else if (is_packed and is_shift and field_type == void)
             ShiftMember
         else
-            f.type;
-        field_names[i] = f.name;
+            field_type;
+        field_names[i] = field_name;
         field_types[i] = FieldType;
         field_attrs[i] = .{
             .@"align" = if (is_packed) null else @alignOf(FieldType),
@@ -905,7 +901,7 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
 
         fn _init(value: T) Self {
             return .{
-                .tag = @intFromEnum(@as(Tag, value)),
+                .tag = @backingInt(@as(Tag, value)),
                 .@"union" = switch (value) {
                     inline else => |v, tag| @unionInit(InnerUnion, @tagName(tag), v),
                 },
@@ -914,7 +910,7 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
 
         fn _initShift(cp: u21, value: T) Self {
             return .{
-                .tag = @intFromEnum(@as(Tag, value)),
+                .tag = @backingInt(@as(Tag, value)),
                 .@"union" = switch (value) {
                     inline else => |v, tag| if (@FieldType(T, @tagName(tag)) == u21)
                         @unionInit(InnerUnion, @tagName(tag), .init(cp, v))
@@ -927,7 +923,7 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
         }
 
         fn _unpack(self: Self) T {
-            const tag: Tag = @enumFromInt(self.tag);
+            const tag: Tag = @fromBackingInt(@intCast(self.tag));
             return switch (tag) {
                 inline else => |comptime_tag| @unionInit(
                     T,
@@ -938,7 +934,7 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
         }
 
         fn _unshift(self: Self, cp: u21) T {
-            const tag: Tag = @enumFromInt(self.tag);
+            const tag: Tag = @fromBackingInt(@intCast(self.tag));
             return switch (tag) {
                 inline else => |comptime_tag| if (@FieldType(T, @tagName(comptime_tag)) == u21)
                     @unionInit(
@@ -963,11 +959,11 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
 
         pub const Tracking = if (is_shift) UnionShiftTracking else void;
         pub const init = if (is_shift) _initShift else _init;
-        pub const unpack = if (is_shift) void{} else _unpack;
-        pub const unshift = if (is_shift) _unshift else void{};
+        pub const unpack = if (is_shift) {} else _unpack;
+        pub const unshift = if (is_shift) _unshift else {};
 
         pub fn autoHash(self: Self, hasher: anytype) void {
-            const tag: Tag = @enumFromInt(self.tag);
+            const tag: Tag = @fromBackingInt(@intCast(self.tag));
             std.hash.autoHash(hasher, tag);
             switch (tag) {
                 inline else => |comptime_tag| {
@@ -983,7 +979,7 @@ pub fn Union(comptime T: type, comptime _ShiftInt: type, comptime is_packed: boo
             if (a.tag != b.tag) {
                 return false;
             }
-            const tag: Tag = @enumFromInt(a.tag);
+            const tag: Tag = @fromBackingInt(@intCast(a.tag));
             switch (tag) {
                 inline else => |comptime_tag| {
                     const a_v = @field(a.@"union", @tagName(comptime_tag));


### PR DESCRIPTION
Hi, I started migrating uucode to zig 0.17.0 (master snapshot 0.17.0-dev.1737+de207594e).

Zig 0.17.0 changes that affected this code:
1. [struct of arrays approach for Type](https://codeberg.org/ziglang/zig/issues/32046)
2. [void{} -> {}](https://ziggit.dev/t/initializing-void-in-0-17/16975)
3. [@enumFromInt -> @fromBackingInt](https://codeberg.org/ziglang/zig/commit/cb4c344e19a269ac227489a96e2ef53dd077ece0)

One thing I am not sure, looks like `else if (@bitSizeOf(F) != @sizeOf(F) * 8)` is not needed anymore? I did some tests and couldn't reproduce the problem. I might be missing something, could you please help me understand that?

I am more than happy to continue working on this as zig-0.17 is not yet released and there are still some [changes coming](https://codeberg.org/ziglang/zig/milestone/69474?q=&type=all&sort=relevance&state=open&labels=&milestone=69474&project=0&assignee=0&poster=0&archived=false).