### PR TITLE
`case_folding_simple`: don't fall back to T (Turkish)

### DIFF
--- a/src/components.zig
+++ b/src/components.zig
@@ -2394,7 +2394,6 @@ const CaseFoldingSimple = struct {
             const input = inputs.get(i);
             const d = input.case_folding_simple_only.unshift(cp) orelse
                 input.case_folding_common_only.unshift(cp) orelse
-                input.case_folding_turkish_only.unshift(cp) orelse
                 cp;
 
             items[i] = initField(Row, "case_folding_simple", cp, d, tracking);

--- a/src/root.zig
+++ b/src/root.zig
@@ -38,6 +38,15 @@ test "is_alphabetic" {
 test "case_folding_simple" {
     try testing.expectEqual(97, get(.case_folding_simple, 65)); // 'a'
     try testing.expectEqual(97, get(.case_folding_simple, 97)); // 'a'
+
+    // Simple case folding is defined by the C and S entries of CaseFolding.txt.
+    // The T (Turkic) entries must not be used: they are only valid in Turkish
+    // and Azeri locales. Historically case_folding_simple fell back to the T
+    // mapping when a code point had no C or S entry. That only ever affected
+    // U+0130 (which has only F and T entries), folding İ to 'i' instead of
+    // leaving it unchanged (see issue #54).
+    try testing.expectEqual(0x0130, get(.case_folding_simple, 0x0130)); // İ
+    try testing.expectEqual(0x0069, get(.case_folding_turkish_only, 0x0130).?); // 'i'
 }
 
 test "simple_uppercase_mapping" {


### PR DESCRIPTION
This PR fixes a bug that was introduced in a7cd38a with a comment that wasn't copied over in the components work in c73d2cc, then deleted in 47de500:

> // This would seem not to be necessary based on the heading
// of CaseFolding.txt, but U+0130 has only an F and T
// mapping and no S. The T mapping is the same as the
// simple_lowercase_mapping so we use that here.

That was an incorrect reasoning, and now we test that we don't use the T mapping for `case_folding_simple` (see comment below).

Resolves https://github.com/jacobsandlund/uucode/issues/54