### PR TITLE
Fix multi_slice bug on packed fields (additionaly signed ints)

### DIFF
--- a/src/multi_slice.zig
+++ b/src/multi_slice.zig
@@ -72,15 +72,18 @@ pub fn MultiSlice(comptime T: type) type {
                 if (@sizeOf(F) == 0) {
                     // Zero-size types have nothing to set.
                 } else if (@bitSizeOf(F) != @sizeOf(F) * 8) {
-                    // Types like bool, u3, or enum(u2) have fewer bits than
-                    // their storage size, so @memset can't be called directly
-                    // on their slices. Convert to a byte-array representation
-                    // by zero-extending into a storage-sized int, then @memset
+                    // Types like bool, u3, enum(u2), or packed struct { data:
+                    // i14 } have fewer bits than their storage size, so
+                    // @memset can't be called directly on their slices.
+                    // Convert to a byte-array representation by bit-casting
+                    // to an unsigned int of the same bit width and
+                    // zero-extending into a storage-sized int, then @memset
                     // the reinterpreted byte array for the same performance as
                     // a normal @memset.
                     const StorageInt = std.meta.Int(.unsigned, @sizeOf(F) * 8);
+                    const IntEquivalent = std.meta.Int(.unsigned, @bitSizeOf(F));
                     const storage: StorageInt = switch (@typeInfo(F)) {
-                        .int => @intCast(value),
+                        .int, .@"struct", .@"union" => @as(IntEquivalent, @bitCast(value)),
                         .bool => @intFromBool(value),
                         .@"enum" => @intFromEnum(value),
                         else => @compileError("memset: unsupported non-byte-aligned type '" ++ @typeName(F) ++ "'"),
@@ -288,6 +291,54 @@ test "memset small enum field" {
 
     ms.memset(.{ .a = .red, .b = 0 });
     try std.testing.expectEqual(Color.red, ms.items(.a)[0]);
+}
+
+test "memset small signed int field" {
+    const Row = struct {
+        a: i14,
+        b: u8,
+    };
+    const MS = MultiSlice(Row);
+
+    var ms = try MS.initCapacity(std.testing.allocator, 4);
+    defer std.testing.allocator.free(@as([*]u8, @ptrCast(@alignCast(ms.ptrs[MS.sorted_fields[0]])))[0..MS.capacityInBytes(4)]);
+
+    ms.len = 4;
+    ms.memset(.{ .a = -7615, .b = 7 });
+
+    for (0..4) |i| {
+        try std.testing.expectEqual(@as(i14, -7615), ms.items(.a)[i]);
+        try std.testing.expectEqual(7, ms.items(.b)[i]);
+    }
+
+    ms.memset(.{ .a = std.math.maxInt(i14), .b = 0 });
+    try std.testing.expectEqual(@as(i14, std.math.maxInt(i14)), ms.items(.a)[0]);
+}
+
+test "memset packed struct field" {
+    // Mirrors `storage.Shift` with `is_packed`, which is what packed shift
+    // fields such as `case_folding_simple_only` become in a packed table.
+    // See https://github.com/jacobsandlund/uucode/issues/55
+    const Shift = packed struct { data: i14 };
+    const Row = struct {
+        a: Shift,
+        b: u8,
+    };
+    const MS = MultiSlice(Row);
+
+    var ms = try MS.initCapacity(std.testing.allocator, 4);
+    defer std.testing.allocator.free(@as([*]u8, @ptrCast(@alignCast(ms.ptrs[MS.sorted_fields[0]])))[0..MS.capacityInBytes(4)]);
+
+    ms.len = 4;
+    ms.memset(.{ .a = .{ .data = std.math.maxInt(i14) }, .b = 7 });
+
+    for (0..4) |i| {
+        try std.testing.expectEqual(@as(i14, std.math.maxInt(i14)), ms.items(.a)[i].data);
+        try std.testing.expectEqual(7, ms.items(.b)[i]);
+    }
+
+    ms.memset(.{ .a = .{ .data = -42 }, .b = 0 });
+    try std.testing.expectEqual(@as(i14, -42), ms.items(.a)[0].data);
 }
 
 test "zero-field struct" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -286,16 +286,39 @@ test "case_folding_full" {
 test "case_folding_turkish_only" {
     // U+0049 'I' has Turkish-only case folding to U+0131 (ı)
     try testing.expectEqual(0x0131, get(.case_folding_turkish_only, 0x0049).?);
+    // U+0130 (İ) has Turkish-only case folding to U+0069 'i'
+    try testing.expectEqual(0x0069, get(.case_folding_turkish_only, 0x0130).?);
+    try testing.expectEqual(null, get(.case_folding_turkish_only, 0x0041));
 }
 
 test "case_folding_common_only" {
     // U+0041 'A' has common case folding to U+0061 'a'
     try testing.expectEqual(0x0061, get(.case_folding_common_only, 0x0041).?);
+    // U+1E9E (ẞ) only has full and simple case folding
+    try testing.expectEqual(null, get(.case_folding_common_only, 0x1E9E));
+    // U+1E921 (Adlam capital sha) to U+1E943, above the ASCII range
+    try testing.expectEqual(0x1E943, get(.case_folding_common_only, 0x1E921).?);
 }
 
 test "case_folding_simple_only" {
     // U+1E9E (ẞ) has simple-only case folding to U+00DF (ß)
     try testing.expectEqual(0x00DF, get(.case_folding_simple_only, 0x1E9E).?);
+    // U+1F88 has simple-only case folding to U+1F80
+    try testing.expectEqual(0x1F80, get(.case_folding_simple_only, 0x1F88).?);
+    try testing.expectEqual(null, get(.case_folding_simple_only, 0x0041));
+}
+
+test "case_folding _only fields in a packed table" {
+    // The `_only` fields are in the packed `case_only` table in the test
+    // config, so every code point's default row goes through
+    // `MultiSlice.memset` with packed shift structs.
+    // See https://github.com/jacobsandlund/uucode/issues/55
+    try testing.expectEqual(null, get(.case_folding_turkish_only, 0x10FFFF));
+    try testing.expectEqual(null, get(.case_folding_common_only, 0x10FFFF));
+    try testing.expectEqual(null, get(.case_folding_simple_only, 0x10FFFF));
+    try testing.expectEqual(null, get(.case_folding_turkish_only, 0x0000));
+    try testing.expectEqual(null, get(.case_folding_common_only, 0x0000));
+    try testing.expectEqual(null, get(.case_folding_simple_only, 0x0000));
 }
 
 test "case_folding_full_only" {

--- a/src/test/build_config.zig
+++ b/src/test/build_config.zig
@@ -223,9 +223,6 @@ pub const tables: []const config.Table = &.{
             "unicode_1_name",
             "has_special_casing",
             "case_folding_full",
-            "case_folding_turkish_only",
-            "case_folding_common_only",
-            "case_folding_simple_only",
             "case_folding_full_only",
             "special_titlecase_mapping",
             "special_uppercase_mapping",
@@ -235,6 +232,19 @@ pub const tables: []const config.Table = &.{
             "uppercase_mapping",
             "lowercase_mapping",
             "titlecase_mapping",
+        },
+    },
+    .{
+        // Packed shift fields in a table are represented as packed structs
+        // with non-byte-sized ints, which `MultiSlice.memset` must handle
+        // when the `CaseFolding` component fills in its default row.
+        // See https://github.com/jacobsandlund/uucode/issues/55
+        .name = "case_only",
+        .packing = .@"packed",
+        .fields = &.{
+            "case_folding_turkish_only",
+            "case_folding_common_only",
+            "case_folding_simple_only",
         },
     },
     .{


### PR DESCRIPTION
Resolves https://github.com/jacobsandlund/uucode/issues/55

This resolves an issue with the code in multi_slice.zig that prepares for calling @memset when the element contains a packed struct, packed union, or signed integer, which was causing the failed compilation.

That switch only handled positive integers bools and enums, so other types hit the @compileError. Now we handle them by bit-casting and zero-extending the `storage` value that we pass to @memset.